### PR TITLE
geom_alt props

### DIFF
--- a/data/421/174/871/421174871.geojson
+++ b/data/421/174/871/421174871.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"LC",
     "wof:created":1459009046,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5193c9e2ea80185a15a719d2e93f852",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421174871,
-    "wof:lastmodified":1566594094,
+    "wof:lastmodified":1582343810,
     "wof:name":"Anse la Raye",
     "wof:parent_id":85673675,
     "wof:placetype":"locality",

--- a/data/421/186/633/421186633.geojson
+++ b/data/421/186/633/421186633.geojson
@@ -381,6 +381,9 @@
     },
     "wof:country":"LC",
     "wof:created":1459009487,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af5884cc98892b487b8a87dc53c19d80",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
         }
     ],
     "wof:id":421186633,
-    "wof:lastmodified":1566594094,
+    "wof:lastmodified":1582343810,
     "wof:name":"Castries",
     "wof:parent_id":85673679,
     "wof:placetype":"locality",

--- a/data/856/323/69/85632369.geojson
+++ b/data/856/323/69/85632369.geojson
@@ -915,6 +915,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -970,6 +971,10 @@
     },
     "wof:country":"LC",
     "wof:country_alpha3":"LCA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"3770b53665e6e3855e935f5e3c20d7fc",
     "wof:hierarchy":[
         {
@@ -984,7 +989,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566594087,
+    "wof:lastmodified":1582343809,
     "wof:name":"Saint Lucia",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/323/69/85632369.geojson
+++ b/data/856/323/69/85632369.geojson
@@ -915,7 +915,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -989,7 +988,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1582343809,
+    "wof:lastmodified":1583222762,
     "wof:name":"Saint Lucia",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.