### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/173/067/421173067.geojson
+++ b/data/421/173/067/421173067.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0641\u0631\u064a\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0641\u0631\u064a\u064a\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Soufri\u00e8re"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u09ab\u09cd\u09b0\u09bf\u09b0\u09c7"
     ],
@@ -180,7 +186,7 @@
         }
     ],
     "wof:id":421173067,
-    "wof:lastmodified":1566594094,
+    "wof:lastmodified":1690938526,
     "wof:name":"Soufri\u00e8re",
     "wof:parent_id":85673711,
     "wof:placetype":"locality",

--- a/data/421/174/871/421174871.geojson
+++ b/data/421/174/871/421174871.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Anse La Raye"
+    ],
     "name:ceb_x_preferred":[
         "Anse La Raye"
     ],
@@ -35,6 +38,9 @@
     "name:fra_x_preferred":[
         "Anse-la-Raye"
     ],
+    "name:ita_x_preferred":[
+        "Anse-la-Raye"
+    ],
     "name:jpn_x_preferred":[
         "\u30a2\u30f3\u30b9\u30fb\u30e9\u30fb\u30ec\u30a4"
     ],
@@ -43,6 +49,9 @@
     ],
     "name:pol_x_preferred":[
         "Anse la Raye"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u043d\u0441-\u043b\u0430-\u0420\u0435\u0439"
     ],
     "name:spa_x_preferred":[
         "Anse La Raye"
@@ -108,7 +117,7 @@
         }
     ],
     "wof:id":421174871,
-    "wof:lastmodified":1582343810,
+    "wof:lastmodified":1690938525,
     "wof:name":"Anse la Raye",
     "wof:parent_id":85673675,
     "wof:placetype":"locality",

--- a/data/421/176/683/421176683.geojson
+++ b/data/421/176/683/421176683.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_variant":[
         "\u062a\u0634\u0648\u064a\u0633\u064a\u0648\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0634\u0648\u064a\u0633\u064a\u0648\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Choiseul"
+    ],
     "name:bar_x_preferred":[
         "Choiseul"
     ],
@@ -111,7 +117,7 @@
         "\u0b9a\u0bcb\u0baf\u0bcd\u0b9a\u0bc7\u0baf\u0bc1\u0bb3\u0bcd"
     ],
     "name:tam_x_variant":[
-        "\u0b9a\u0bcb\u0baf\u0bcd\u0b9a\u0bc7\u0baf\u0bc1\u0bb3\u0bcd"
+        "\u0b9a\u0bcb\u0baf\u0bcd\u0b9a\u0bc7\u0baf\u0bc1\u0bb3\u0bcd "
     ],
     "name:tel_x_preferred":[
         "\u0c1a\u0c3e\u0c2f\u0c3f\u0c38\u0c3f\u0c2f\u0c32\u0c4d \u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c32\u0c42\u0c38\u0c3f\u0c2f\u0c3e"
@@ -133,7 +139,8 @@
     ],
     "name:urd_x_variant":[
         "\u0686\u0648\u06cc\u0633\u06cc\u0648\u0644",
-        "\u0686\u0648\u06cc\u0633\u06cc\u0648\u0644 \u060c \u0633\u06cc\u0646\u0679 \u0644\u0648\u06a9\u06cc\u0627"
+        "\u0686\u0648\u06cc\u0633\u06cc\u0648\u0644 \u060c \u0633\u06cc\u0646\u0679 \u0644\u0648\u06a9\u06cc\u0627",
+        "\u0686\u0648\u06cc\u0633\u06cc\u0648\u0644 "
     ],
     "name:vie_x_preferred":[
         "Choiseul"
@@ -190,7 +197,7 @@
         }
     ],
     "wof:id":421176683,
-    "wof:lastmodified":1636500441,
+    "wof:lastmodified":1690938527,
     "wof:name":"Choiseul",
     "wof:parent_id":85673683,
     "wof:placetype":"locality",

--- a/data/421/183/649/421183649.geojson
+++ b/data/421/183/649/421183649.geojson
@@ -17,6 +17,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Laborie"
+    ],
+    "name:ceb_x_preferred":[
+        "Laborie"
+    ],
+    "name:ces_x_preferred":[
+        "Laborie"
+    ],
     "name:cym_x_preferred":[
         "Laborie"
     ],
@@ -29,10 +38,19 @@
     "name:eng_x_preferred":[
         "Laborie"
     ],
+    "name:fra_x_preferred":[
+        "Laborie"
+    ],
     "name:heb_x_preferred":[
         "\u05dc\u05d0\u05d1\u05d5\u05e8\u05d9"
     ],
+    "name:hrv_x_preferred":[
+        "Laborie"
+    ],
     "name:hun_x_preferred":[
+        "Laborie"
+    ],
+    "name:ita_x_preferred":[
         "Laborie"
     ],
     "name:jpn_x_preferred":[
@@ -47,7 +65,13 @@
     "name:pol_x_preferred":[
         "Laborie"
     ],
+    "name:slk_x_preferred":[
+        "Laborie"
+    ],
     "name:spa_x_preferred":[
+        "Laborie"
+    ],
+    "name:swe_x_preferred":[
         "Laborie"
     ],
     "name:urd_x_preferred":[
@@ -105,7 +129,7 @@
         }
     ],
     "wof:id":421183649,
-    "wof:lastmodified":1636500440,
+    "wof:lastmodified":1690938527,
     "wof:name":"Laborie",
     "wof:parent_id":85673699,
     "wof:placetype":"locality",

--- a/data/421/186/011/421186011.geojson
+++ b/data/421/186/011/421186011.geojson
@@ -62,6 +62,9 @@
     "name:nld_x_preferred":[
         "Reduit"
     ],
+    "name:nld_x_variant":[
+        "reduit"
+    ],
     "name:nob_x_preferred":[
         "R\u00e9duit"
     ],
@@ -85,6 +88,9 @@
     ],
     "name:slv_x_preferred":[
         "Nacionalna pregrada"
+    ],
+    "name:srp_x_preferred":[
+        "\u0420\u0435\u0434\u0432\u0438"
     ],
     "name:ukr_x_preferred":[
         "\u0420\u0435\u0434\u044e\u0456\u0442"
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":421186011,
-    "wof:lastmodified":1566594094,
+    "wof:lastmodified":1690938526,
     "wof:name":"Reduit",
     "wof:parent_id":85673695,
     "wof:placetype":"locality",

--- a/data/421/186/633/421186633.geojson
+++ b/data/421/186/633/421186633.geojson
@@ -31,11 +31,26 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0633\u062a\u0631\u064a\u0633"
     ],
+    "name:arg_x_preferred":[
+        "Castries"
+    ],
+    "name:ary_x_preferred":[
+        "\u0643\u0627\u0633\u062a\u0631\u064a\u0633"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0633\u062a\u0631\u064a\u0633"
+    ],
     "name:ast_x_preferred":[
+        "Castries"
+    ],
+    "name:avk_x_preferred":[
         "Castries"
     ],
     "name:aze_x_preferred":[
         "Kastris"
+    ],
+    "name:ban_x_preferred":[
+        "Castries"
     ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0441\u0442\u0440\u044b"
@@ -79,6 +94,9 @@
     "name:deu_x_preferred":[
         "Castries"
     ],
+    "name:diq_x_preferred":[
+        "Castries"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03ac\u03c3\u03c4\u03c1\u03b9\u03c2"
     ],
@@ -103,10 +121,16 @@
     "name:fra_x_preferred":[
         "Castries"
     ],
+    "name:frr_x_preferred":[
+        "Castries"
+    ],
     "name:fry_x_preferred":[
         "Kastrys"
     ],
     "name:gla_x_preferred":[
+        "Castries"
+    ],
+    "name:gle_x_preferred":[
         "Castries"
     ],
     "name:glg_x_preferred":[
@@ -187,6 +211,9 @@
     "name:lav_x_preferred":[
         "Kastri"
     ],
+    "name:lij_x_preferred":[
+        "Castries"
+    ],
     "name:lit_x_preferred":[
         "Kastris"
     ],
@@ -238,6 +265,9 @@
     "name:olo_x_preferred":[
         "Kastri"
     ],
+    "name:oss_x_preferred":[
+        "\u041a\u0430\u0441\u0442\u0440\u0438"
+    ],
     "name:pan_x_preferred":[
         "\u0a15\u0a3e\u0a38\u0a24\u0a30\u0a40\u0a38"
     ],
@@ -248,6 +278,9 @@
         "Castries"
     ],
     "name:por_x_preferred":[
+        "Castries"
+    ],
+    "name:ron_x_preferred":[
         "Castries"
     ],
     "name:rus_x_preferred":[
@@ -274,6 +307,9 @@
     "name:spa_x_preferred":[
         "Castries"
     ],
+    "name:srd_x_preferred":[
+        "Castries"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0441\u0442\u0440\u0438"
     ],
@@ -295,6 +331,9 @@
     "name:tel_x_preferred":[
         "\u0c15\u0c4d\u0c2f\u0c3e\u0c38\u0c4d\u0c1f\u0c4d\u0c30\u0c40\u0c38\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0430\u0441\u0442\u0440\u0438\u0441"
+    ],
     "name:tgl_x_preferred":[
         "Castries"
     ],
@@ -303,6 +342,9 @@
     ],
     "name:tur_x_preferred":[
         "Castries"
+    ],
+    "name:udm_x_preferred":[
+        "\u041a\u0430\u0441\u0442\u0440\u0438"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0441\u0442\u0440\u0456"
@@ -324,6 +366,9 @@
     ],
     "name:war_x_preferred":[
         "Castries"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5361\u65af\u7279\u91cc"
     ],
     "name:xmf_x_preferred":[
         "\u10d9\u10d0\u10e1\u10e2\u10e0\u10d8"
@@ -399,7 +444,7 @@
         }
     ],
     "wof:id":421186633,
-    "wof:lastmodified":1636500440,
+    "wof:lastmodified":1690938526,
     "wof:name":"Castries",
     "wof:parent_id":85673679,
     "wof:placetype":"locality",

--- a/data/421/187/303/421187303.geojson
+++ b/data/421/187/303/421187303.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Vigie"
     ],
+    "name:nld_x_preferred":[
+        "Vigie"
+    ],
     "qs:gn_country":"LC",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":3576408,
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421187303,
-    "wof:lastmodified":1566594094,
+    "wof:lastmodified":1690938526,
     "wof:name":"Vigie",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/190/711/421190711.geojson
+++ b/data/421/190/711/421190711.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Micoud"
+    ],
     "name:ceb_x_preferred":[
         "Micoud"
     ],
@@ -30,6 +33,9 @@
         "\u05d0\u05d5\u05dc\u05e1\u05d8\u05e8 \u05ea\u05d9\u05db\u05d5\u05e0\u05d4"
     ],
     "name:hun_x_preferred":[
+        "Micoud"
+    ],
+    "name:ita_x_preferred":[
         "Micoud"
     ],
     "name:jpn_x_preferred":[
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":421190711,
-    "wof:lastmodified":1636500440,
+    "wof:lastmodified":1690938526,
     "wof:name":"Micoud",
     "wof:parent_id":85673703,
     "wof:placetype":"locality",

--- a/data/421/201/343/421201343.geojson
+++ b/data/421/201/343/421201343.geojson
@@ -17,8 +17,47 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Gros Islet"
+    ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u064a\u0631\u0629 \u062c\u0648\u0631\u0633"
+    ],
+    "name:arg_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u0632\u064a\u0631\u0629 \u062c\u0648\u0631\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:bar_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:bos_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:bre_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:cat_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:ces_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:cor_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:cos_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:cym_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:dan_x_preferred":[
+        "Gros Islet"
     ],
     "name:deu_x_preferred":[
         "Gros Islet"
@@ -29,10 +68,37 @@
     "name:eng_x_preferred":[
         "Gros Islet"
     ],
+    "name:epo_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:est_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:eus_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:fao_x_preferred":[
+        "Gros Islet"
+    ],
     "name:fas_x_preferred":[
         "\u06af\u0631\u0627\u0633 \u0627\u06cc\u0632\u0644\u062a"
     ],
+    "name:fin_x_preferred":[
+        "Gros Islet"
+    ],
     "name:fra_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:gla_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:gle_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:glg_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:glv_x_preferred":[
         "Gros Islet"
     ],
     "name:heb_x_preferred":[
@@ -41,7 +107,19 @@
     "name:heb_x_variant":[
         "\u05d2\u05e8\u05d5 \u05d0\u05d9\u05e1\u05dc\u05d8"
     ],
+    "name:hin_x_preferred":[
+        "\u0917\u094d\u0930\u094b\u0938 \u0906\u0907\u0932\u0947\u091f"
+    ],
+    "name:hrv_x_preferred":[
+        "Gros Islet"
+    ],
     "name:hun_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:ind_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:isl_x_preferred":[
         "Gros Islet"
     ],
     "name:ita_x_preferred":[
@@ -50,16 +128,67 @@
     "name:jpn_x_preferred":[
         "\u30b0\u30ed\u30b9\u30fb\u30a4\u30b9\u30ec\u30c3\u30c8"
     ],
+    "name:lav_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:lit_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:ltz_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:mlt_x_preferred":[
+        "Gros Islet"
+    ],
     "name:nld_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:nno_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:nrm_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:oci_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:pms_x_preferred":[
         "Gros Islet"
     ],
     "name:pol_x_preferred":[
         "Gros Islet"
     ],
+    "name:por_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:roh_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:ron_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:slk_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:slv_x_preferred":[
+        "Gros Islet"
+    ],
     "name:spa_x_preferred":[
         "Gros Islet"
     ],
+    "name:sqi_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:srp_x_preferred":[
+        "\u0413\u0440\u043e\u0441 \u0418\u043b\u0435"
+    ],
     "name:swe_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:tah_x_preferred":[
+        "Gros Islet"
+    ],
+    "name:tur_x_preferred":[
         "Gros Islet"
     ],
     "name:und_x_variant":[
@@ -68,8 +197,14 @@
     "name:urd_x_preferred":[
         "\u062c\u0632\u06cc\u0631\u06c1 \u06af\u0631\u0648\u0633"
     ],
+    "name:wln_x_preferred":[
+        "Gros Islet"
+    ],
     "name:zho_x_preferred":[
         "\u683c\u7f85\u65af\u4f0a\u65af\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "Gros Islet"
     ],
     "qs:gn_country":"LC",
     "qs:gn_fcode":"PPL",
@@ -120,7 +255,7 @@
         }
     ],
     "wof:id":421201343,
-    "wof:lastmodified":1636500440,
+    "wof:lastmodified":1690938527,
     "wof:name":"Gros Islet",
     "wof:parent_id":85673695,
     "wof:placetype":"locality",

--- a/data/421/202/879/421202879.geojson
+++ b/data/421/202/879/421202879.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Vieux Fort"
+    ],
     "name:ceb_x_preferred":[
         "Vieux Fort"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:eng_x_preferred":[
         "Vieux Fort"
+    ],
+    "name:fas_x_preferred":[
+        "\u0648\u06cc\u0648 \u0641\u0648\u0631\u062a"
     ],
     "name:fra_x_preferred":[
         "Vieux Fort"
@@ -41,6 +47,9 @@
     "name:hun_x_preferred":[
         "Vieux Fort"
     ],
+    "name:ita_x_preferred":[
+        "Vieux Fort"
+    ],
     "name:jpn_x_preferred":[
         "\u30f4\u30e5\u30fc\u30d5\u30a9\u30fc\u30c8"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:pol_x_preferred":[
         "Vieux Fort"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u044c\u0451-\u0424\u043e\u0440"
     ],
     "name:spa_x_preferred":[
         "Vieux Fort"
@@ -113,7 +125,7 @@
         }
     ],
     "wof:id":421202879,
-    "wof:lastmodified":1636500440,
+    "wof:lastmodified":1690938525,
     "wof:name":"Vieux Fort",
     "wof:parent_id":85673717,
     "wof:placetype":"locality",

--- a/data/856/323/69/85632369.geojson
+++ b/data/856/323/69/85632369.geojson
@@ -47,8 +47,14 @@
     "name:amh_x_variant":[
         "\u1234\u1295\u1275 \u1209\u127a\u12eb"
     ],
+    "name:ami_x_preferred":[
+        "Saint Lucia"
+    ],
     "name:ang_x_preferred":[
         "Sancte Luc\u012ba"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u0947\u0902\u091f \u0932\u0942\u0938\u093f\u092f\u093e"
     ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0644\u0648\u0633\u064a\u0627"
@@ -89,6 +95,9 @@
     "name:bam_x_preferred":[
         "Lusi-Senu"
     ],
+    "name:ban_x_preferred":[
+        "Saint Lucia"
+    ],
     "name:bar_x_preferred":[
         "St. Lucia"
     ],
@@ -104,6 +113,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09b2\u09c1\u09b8\u09bf\u09af\u09bc\u09be"
+    ],
+    "name:bis_x_preferred":[
+        "Sen Lusia"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f7a\u0f53\u0f0b\u0f4a\u0f0b\u0f63\u0f74\u0f0b\u0f64\u0f72\u0f0b\u0f61\u0f0d"
@@ -160,6 +172,9 @@
     "name:cor_x_preferred":[
         "Sen Lusia"
     ],
+    "name:cos_x_preferred":[
+        "Saint Lucia"
+    ],
     "name:crh_x_preferred":[
         "Sent Lusiya"
     ],
@@ -167,6 +182,9 @@
         "Sant Lwsia"
     ],
     "name:cym_x_variant":[
+        "Saint Lucia"
+    ],
+    "name:dag_x_preferred":[
         "Saint Lucia"
     ],
     "name:dan_x_preferred":[
@@ -414,6 +432,9 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30eb\u30b7\u30a2"
     ],
+    "name:kaa_x_preferred":[
+        "Sent-Lyusiya"
+    ],
     "name:kal_x_preferred":[
         "Saint Lucia"
     ],
@@ -492,6 +513,9 @@
     "name:lit_x_variant":[
         "\u0160ventoji Liucija"
     ],
+    "name:lld_x_preferred":[
+        "Santa Luzia"
+    ],
     "name:lmo_x_preferred":[
         "Santa L\u00fczia"
     ],
@@ -507,6 +531,9 @@
     "name:lzh_x_preferred":[
         "\u8056\u9732\u897f\u4e9e"
     ],
+    "name:mad_x_preferred":[
+        "Saint Lucia"
+    ],
     "name:mal_x_preferred":[
         "\u0d38\u0d46\u0d2f\u0d4d\u0d28\u0d4d\u0d31\u0d4d \u0d32\u0d42\u0d38\u0d3f\u0d2f"
     ],
@@ -521,6 +548,15 @@
     ],
     "name:mdf_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u041b\u044e\u0441\u0438\u0435"
+    ],
+    "name:mdf_x_variant":[
+        "\u0421\u044d\u043d\u0442-\u041b\u044e\u0441\u0438\u044f"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u041b\u044e\u0441\u0438\u0439"
+    ],
+    "name:min_x_preferred":[
+        "Saint Lucia"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0430 \u041b\u0443\u0446\u0438\u0458\u0430"
@@ -539,6 +575,12 @@
     ],
     "name:mlt_x_variant":[
         "Saint Lucia"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe6\uabdf\uabe0 \uabc2\uabe8\uabc1\uabe4\uabcc\uabe5"
+    ],
+    "name:mri_x_preferred":[
+        "H\u0101to Ruiha"
     ],
     "name:msa_x_preferred":[
         "Saint Lucia"
@@ -676,6 +718,9 @@
     "name:sgs_x_preferred":[
         "Sent Lius\u0117j\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1035\u1004\u103a\u1089\u101c\u1030\u1089\u101e\u103b\u1083\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0dbd\u0dd4\u0dc3\u0dd2\u0dba\u0dcf"
     ],
@@ -686,12 +731,19 @@
         "Sveta Lucija (dr\u017eava)"
     ],
     "name:slv_x_variant":[
-        "Saint Lucia"
+        "Saint Lucia",
+        "Sveta Lucija"
     ],
     "name:sme_x_preferred":[
         "Saint Lucia"
     ],
+    "name:smn_x_preferred":[
+        "Saint Lucia"
+    ],
     "name:smo_x_preferred":[
+        "Saint Lucia"
+    ],
+    "name:sms_x_preferred":[
         "Saint Lucia"
     ],
     "name:sna_x_preferred":[
@@ -765,6 +817,9 @@
     "name:tet_x_preferred":[
         "Santa L\u00fasia"
     ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u041b\u044e\u0441\u0438\u044f"
+    ],
     "name:tgl_x_preferred":[
         "Santa Lucia (bansa)"
     ],
@@ -783,6 +838,9 @@
     ],
     "name:ton_x_preferred":[
         "Seini Lusia"
+    ],
+    "name:ton_x_variant":[
+        "S\u0101 L\u016bsia"
     ],
     "name:tuk_x_preferred":[
         "Sent-L\u00fdusi\u00fda"
@@ -816,6 +874,9 @@
     ],
     "name:uzb_x_variant":[
         "Saint Lucia"
+    ],
+    "name:vec_x_preferred":[
+        "St. Lucia"
     ],
     "name:vep_x_preferred":[
         "Sent L\u00fcsii"
@@ -1109,7 +1170,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500439,
+    "wof:lastmodified":1690938525,
     "wof:name":"Saint Lucia",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/736/75/85673675.geojson
+++ b/data/856/736/75/85673675.geojson
@@ -95,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uc559\uc2a4\ub77c\ub808 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc559\uc2a4\ub77c\ub808\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Anslavua"
     ],
@@ -124,6 +127,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0410\u043d\u0441-\u041b\u0430\u0432\u0443\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u0410\u043d\u0441-\u043b\u0430-\u0420\u0435\u0439"
     ],
     "name:sin_x_preferred":[
         "\u0d85\u0db1\u0dca\u0dc3\u0dda \u0dbd\u0dcf \u0dbb\u0dba\u0dda \u0d9a\u0dcf\u0dbb\u0dca\u0da7\u0dbb\u0dca"
@@ -278,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938524,
     "wof:name":"Anse-la-Raye",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/79/85673679.geojson
+++ b/data/856/736/79/85673679.geojson
@@ -50,6 +50,9 @@
     "name:eng_x_variant":[
         "Castries Quarter"
     ],
+    "name:epo_x_preferred":[
+        "Castries"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u062e\u0634 \u06a9\u0627\u0633\u062a\u0631\u06cc\u0633"
     ],
@@ -80,6 +83,9 @@
     "name:kor_x_preferred":[
         "\uce90\uc2a4\ud2b8\ub9ac\uc2a4 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uce90\uc2a4\ud2b8\ub9ac\uc2a4\uad6c"
+    ],
     "name:lit_x_preferred":[
         "Kastrio kvartalas"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:tur_x_preferred":[
         "Castries"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0430\u0441\u0442\u0440\u0456"
     ],
     "name:und_x_variant":[
         "Quarter of Castries"
@@ -243,7 +252,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500439,
+    "wof:lastmodified":1690938524,
     "wof:name":"Castries",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/83/85673683.geojson
+++ b/data/856/736/83/85673683.geojson
@@ -62,6 +62,9 @@
     "name:kor_x_preferred":[
         "\uc288\uc544\uc8cc \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc288\uc544\uc8cc\uad6c"
+    ],
     "name:lit_x_preferred":[
         "\u0160uazelis"
     ],
@@ -216,7 +219,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500439,
+    "wof:lastmodified":1690938524,
     "wof:name":"Choiseul",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/87/85673687.geojson
+++ b/data/856/736/87/85673687.geojson
@@ -76,6 +76,9 @@
     "name:kor_x_preferred":[
         "\ub3c4\ud33d \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub3c4\ud33d\uad6c"
+    ],
     "name:lit_x_preferred":[
         "Daufinas"
     ],
@@ -90,6 +93,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u043e\u0444\u0438\u043d"
+    ],
+    "name:rus_x_variant":[
+        "\u0414\u043e\u0444\u0435\u043d"
     ],
     "name:spa_x_preferred":[
         "Dauphin"
@@ -214,7 +220,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938523,
     "wof:name":"Dauphin",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/89/85673689.geojson
+++ b/data/856/736/89/85673689.geojson
@@ -95,6 +95,9 @@
     "name:kor_x_preferred":[
         "\ub370\ub124\ub9ac \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub370\ub124\ub9ac\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Dener\u012b"
     ],
@@ -276,7 +279,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938523,
     "wof:name":"Dennery",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/95/85673695.geojson
+++ b/data/856/736/95/85673695.geojson
@@ -37,6 +37,12 @@
     "name:ben_x_preferred":[
         "\u0997\u09cd\u09b0\u09cb\u09b8 \u0987\u099c\u09b2\u09c7\u099f \u0995\u09cb\u09af\u09bc\u09be\u09b0\u09cd\u099f\u09be\u09b0"
     ],
+    "name:ben_x_variant":[
+        "\u0997\u09cd\u09b0\u09cb\u09b8  \u0987\u099c\u09b2\u09c7\u099f \u0995\u09cb\u09af\u09bc\u09be\u09b0\u09cd\u099f\u09be\u09b0"
+    ],
+    "name:cat_x_preferred":[
+        "Gros Islet"
+    ],
     "name:ceb_x_preferred":[
         "Gros-Islet"
     ],
@@ -90,6 +96,9 @@
     ],
     "name:kor_x_preferred":[
         "\uadf8\ub85c\uc2a4\uc544\uc77c\ub81b \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uadf8\ub85c\uc2a4\uc544\uc77c\ub81b\uad6c"
     ],
     "name:lav_x_preferred":[
         "Grozil\u0113"
@@ -150,6 +159,9 @@
     ],
     "name:zho_x_preferred":[
         "\u683c\u7f85\u65af\u4f0a\u65af\u52d2\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u683c\u7f57\u827e\u52d2\u7279\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LCA",
@@ -269,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938523,
     "wof:name":"Gros Islet",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/99/85673699.geojson
+++ b/data/856/736/99/85673699.geojson
@@ -101,6 +101,9 @@
     "name:kor_x_preferred":[
         "\ub77c\ubcf4\ub9ac \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub77c\ubcf4\ub9ac\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Labor\u012b"
     ],
@@ -282,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500439,
+    "wof:lastmodified":1690938524,
     "wof:name":"Laborie",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/03/85673703.geojson
+++ b/data/856/737/03/85673703.geojson
@@ -96,6 +96,9 @@
     "name:kor_x_preferred":[
         "\ubbf8\ucfe0 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubbf8\ucfe0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Mik\u016b"
     ],
@@ -280,7 +283,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500437,
+    "wof:lastmodified":1690938522,
     "wof:name":"Micoud",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/07/85673707.geojson
+++ b/data/856/737/07/85673707.geojson
@@ -85,6 +85,9 @@
     "name:kor_x_preferred":[
         "\ud504\ub77c\uc2ac\ub7ad \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud504\ub77c\uc2ac\ub7ad\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Prasl\u0113na"
     ],
@@ -247,7 +250,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938523,
     "wof:name":"Praslin",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/11/85673711.geojson
+++ b/data/856/737/11/85673711.geojson
@@ -68,6 +68,9 @@
     "name:kor_x_preferred":[
         "\uc218\ud504\ub9ac\uc5d0\ub974 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc218\ud504\ub9ac\uc5d0\ub974\uad6c"
+    ],
     "name:lit_x_preferred":[
         "Sufrieras"
     ],
@@ -222,7 +225,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895895,
+    "wof:lastmodified":1690938522,
     "wof:name":"Soufri\u00e8re",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/17/85673717.geojson
+++ b/data/856/737/17/85673717.geojson
@@ -65,6 +65,9 @@
     "name:fra_x_preferred":[
         "Vieux Fort"
     ],
+    "name:gle_x_preferred":[
+        "Vieux Fort"
+    ],
     "name:guj_x_preferred":[
         "\u0ab5\u0abf\u0a8f\u0a95\u0acd\u0ab8 \u0aab\u0acb\u0ab0\u0acd\u0a9f \u0a95\u0acd\u0ab5\u0abe\u0ab0\u0acd\u0a9f\u0ab0"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ube44\uc678\ud3ec\ub974 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ube44\uc678\ud3ec\ub974\uad6c"
     ],
     "name:lav_x_preferred":[
         "Vj\u0113fora"
@@ -270,7 +276,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500438,
+    "wof:lastmodified":1690938522,
     "wof:name":"Vieux Fort",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/890/432/005/890432005.geojson
+++ b/data/890/432/005/890432005.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0627\u0644\u0643\u0646\u0627\u0631\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0632\u0631 \u0627\u0644\u0643\u0646\u0627\u0631\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Canaries"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09a8\u09be\u09b0\u09be\u0987\u09b8\u09c7"
     ],
@@ -170,7 +176,7 @@
         }
     ],
     "wof:id":890432005,
-    "wof:lastmodified":1566594096,
+    "wof:lastmodified":1690938527,
     "wof:name":"Canaries",
     "wof:parent_id":85673711,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.