### PR TITLE
lc concordances, placetype local, and more

### DIFF
--- a/data/856/323/69/85632369.geojson
+++ b/data/856/323/69/85632369.geojson
@@ -1140,6 +1140,7 @@
         "hasc:id":"LC",
         "icao:code":"J6",
         "ioc:id":"LCA",
+        "iso:code":"LC",
         "itu:id":"LCA",
         "loc:id":"n79034961",
         "m49:code":"662",
@@ -1154,6 +1155,7 @@
         "wk:page":"Saint Lucia",
         "wmo:id":"LC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
     "wof:country_alpha3":"LCA",
     "wof:geom_alt":[
@@ -1174,7 +1176,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Saint Lucia",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/736/75/85673675.geojson
+++ b/data/856/736/75/85673675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006486,
-    "geom:area_square_m":77836107.897333,
+    "geom:area_square_m":77836655.286678,
     "geom:bbox":"-61.066884,13.866477,-60.980627,13.987372",
     "geom:latitude":13.927987,
     "geom:longitude":-61.013986,
@@ -263,13 +263,15 @@
         "gn:id":3576891,
         "gp:id":2347023,
         "hasc:id":"LC.AR",
+        "iso:code":"LC-01",
         "iso:id":"LC-01",
         "qs_pg:id":900758,
         "unlc:id":"LC-01",
         "wd:id":"Q1676934"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"25d1716a0aa031ce4c18d4a3c4dba677",
+    "wof:geomhash":"193d7abb1ec6b30b47db00141faf40bf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938524,
+    "wof:lastmodified":1695884865,
     "wof:name":"Anse-la-Raye",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/79/85673679.geojson
+++ b/data/856/736/79/85673679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006518,
-    "geom:area_square_m":78211122.797771,
+    "geom:area_square_m":78210708.764621,
     "geom:bbox":"-61.026601,13.87901,-60.935588,14.043524",
     "geom:latitude":13.976414,
     "geom:longitude":-60.972827,
@@ -230,14 +230,16 @@
         "gn:id":3576810,
         "gp:id":2347025,
         "hasc:id":"LC.CS",
+        "iso:code":"LC-02",
         "iso:id":"LC-02",
         "qs_pg:id":1083865,
         "unlc:id":"LC-02",
         "wd:id":"Q1049867",
         "wk:page":"Castries Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"9ab524a3e32eadde6448d28bc5aea2f4",
+    "wof:geomhash":"ae7672739016f169804a7aec4d9cec48",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -252,7 +254,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938524,
+    "wof:lastmodified":1695884866,
     "wof:name":"Castries",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/83/85673683.geojson
+++ b/data/856/736/83/85673683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003145,
-    "geom:area_square_m":37767034.785128,
+    "geom:area_square_m":37767148.608053,
     "geom:bbox":"-61.068105,13.756246,-60.980943,13.835766",
     "geom:latitude":13.794041,
     "geom:longitude":-61.025286,
@@ -197,14 +197,16 @@
         "gn:id":3576794,
         "gp:id":2347026,
         "hasc:id":"LC.CH",
+        "iso:code":"LC-03",
         "iso:id":"LC-03",
         "qs_pg:id":229384,
         "unlc:id":"LC-03",
         "wd:id":"Q1075816",
         "wk:page":"Choiseul Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"e64828c2e06760b91b7c7f31443883fb",
+    "wof:geomhash":"3448d25692b1a276ab05aa5074c60e37",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +221,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938524,
+    "wof:lastmodified":1695884866,
     "wof:name":"Choiseul",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/87/85673687.geojson
+++ b/data/856/736/87/85673687.geojson
@@ -203,10 +203,12 @@
     "wof:concordances":{
         "gn:id":3576771,
         "gp:id":2347024,
+        "iso:code_pseudo":"LC-06",
         "qs_pg:id":507469,
         "wd:id":"Q182988",
         "wk:page":"Dauphin Quarter"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"LC",
     "wof:geomhash":"91c5c3f3dc8cf1a15e8f1557f865de8f",
     "wof:hierarchy":[
@@ -223,7 +225,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884865,
     "wof:name":"Dauphin",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/89/85673689.geojson
+++ b/data/856/736/89/85673689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005146,
-    "geom:area_square_m":61751348.063459,
+    "geom:area_square_m":61751692.840207,
     "geom:bbox":"-60.960575,13.897809,-60.882965,13.983032",
     "geom:latitude":13.940793,
     "geom:longitude":-60.918937,
@@ -257,14 +257,16 @@
         "gn:id":3576764,
         "gp:id":2347027,
         "hasc:id":"LC.DE",
+        "iso:code":"LC-05",
         "iso:id":"LC-05",
         "qs_pg:id":222839,
         "unlc:id":"LC-05",
         "wd:id":"Q1188890",
         "wk:page":"Dennery Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"253cbea43b5497a91e910dec648802ba",
+    "wof:geomhash":"42b1ab9e95f8841535c42d33e1942c6e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938523,
+    "wof:lastmodified":1695884866,
     "wof:name":"Dennery",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/95/85673695.geojson
+++ b/data/856/736/95/85673695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003875,
-    "geom:area_square_m":46478464.663688,
+    "geom:area_square_m":46478541.861509,
     "geom:bbox":"-60.97997,14.017963,-60.901031,14.111884",
     "geom:latitude":14.065256,
     "geom:longitude":-60.943376,
@@ -259,14 +259,16 @@
         "gn:id":3576685,
         "gp:id":2347028,
         "hasc:id":"LC.GI",
+        "iso:code":"LC-06",
         "iso:id":"LC-06",
         "qs_pg:id":222840,
         "unlc:id":"LC-06",
         "wd:id":"Q953557",
         "wk:page":"Gros Islet Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"823fe99aac8b5a9d1ec1ea463595f1ac",
+    "wof:geomhash":"d2b172957ad82442f69874ba27fb5a0e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -281,7 +283,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938523,
+    "wof:lastmodified":1695884866,
     "wof:name":"Gros Islet",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/736/99/85673699.geojson
+++ b/data/856/736/99/85673699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002861,
-    "geom:area_square_m":34364702.753764,
+    "geom:area_square_m":34364513.90802,
     "geom:bbox":"-61.018923,13.730641,-60.96245,13.8308",
     "geom:latitude":13.774661,
     "geom:longitude":-60.985733,
@@ -263,14 +263,16 @@
         "gn:id":3576662,
         "gp:id":2347029,
         "hasc:id":"LC.LB",
+        "iso:code":"LC-07",
         "iso:id":"LC-07",
         "qs_pg:id":1047418,
         "unlc:id":"LC-07",
         "wd:id":"Q599347",
         "wk:page":"Laborie Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"634c74b876484a016e406a6f54c8d3f4",
+    "wof:geomhash":"9babc860877e58e389d1e694e48c0367",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938524,
+    "wof:lastmodified":1695884866,
     "wof:name":"Laborie",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/03/85673703.geojson
+++ b/data/856/737/03/85673703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002919,
-    "geom:area_square_m":35052467.971631,
+    "geom:area_square_m":35052904.301875,
     "geom:bbox":"-60.975223,13.774001,-60.892201,13.845172",
     "geom:latitude":13.814879,
     "geom:longitude":-60.927779,
@@ -261,14 +261,16 @@
         "gn:id":3576567,
         "gp:id":2347030,
         "hasc:id":"LC.MI",
+        "iso:code":"LC-08",
         "iso:id":"LC-08",
         "qs_pg:id":1322126,
         "unlc:id":"LC-08",
         "wd:id":"Q1240193",
         "wk:page":"Micoud Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"c1cb82043a8801c5eb55576eda2ba581",
+    "wof:geomhash":"ff6d453b443a28b1238b709863de7616",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938522,
+    "wof:lastmodified":1695884865,
     "wof:name":"Micoud",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/07/85673707.geojson
+++ b/data/856/737/07/85673707.geojson
@@ -233,10 +233,12 @@
     "wof:concordances":{
         "gn:id":3576507,
         "gp:id":2347033,
+        "iso:code_pseudo":"LC-08",
         "qs_pg:id":1083867,
         "wd:id":"Q1567791",
         "wk:page":"Praslin Quarter"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"LC",
     "wof:geomhash":"526ee0ae073fd45993ccb266f466ca27",
     "wof:hierarchy":[
@@ -253,7 +255,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884866,
     "wof:name":"Praslin",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/11/85673711.geojson
+++ b/data/856/737/11/85673711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007819,
-    "geom:area_square_m":93870700.546996,
+    "geom:area_square_m":93870008.004741,
     "geom:bbox":"-61.078521,13.792182,-60.960575,13.909089",
     "geom:latitude":13.854849,
     "geom:longitude":-61.030443,
@@ -203,14 +203,16 @@
         "gn:id":3576441,
         "gp:id":2347031,
         "hasc:id":"LC.CO",
+        "iso:code":"LC-10",
         "iso:id":"LC-10",
         "qs_pg:id":318870,
         "unlc:id":"LC-10",
         "wd:id":"Q1472841",
         "wk:page":"Soufri\u00e8re Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"6b6f43fd9f097ab9ad980f6cdbecac23",
+    "wof:geomhash":"db25e794d2ba58b2b09276fc82724d37",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -225,7 +227,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938522,
+    "wof:lastmodified":1695884535,
     "wof:name":"Soufri\u00e8re",
     "wof:parent_id":85632369,
     "wof:placetype":"region",

--- a/data/856/737/17/85673717.geojson
+++ b/data/856/737/17/85673717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003466,
-    "geom:area_square_m":41627037.052491,
+    "geom:area_square_m":41627176.648953,
     "geom:bbox":"-60.981578,13.714667,-60.918039,13.839233",
     "geom:latitude":13.775082,
     "geom:longitude":-60.952216,
@@ -254,14 +254,16 @@
         "gn:id":3576413,
         "gp:id":2347032,
         "hasc:id":"LC.VF",
+        "iso:code":"LC-11",
         "iso:id":"LC-11",
         "qs_pg:id":1083866,
         "unlc:id":"LC-11",
         "wd:id":"Q1472864",
         "wk:page":"Vieux Fort Quarter"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LC",
-    "wof:geomhash":"62eabdea27dcbd09e1095ad6154d817c",
+    "wof:geomhash":"24d915d5c4827a91004a27a4f27cbb8d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938522,
+    "wof:lastmodified":1695884866,
     "wof:name":"Vieux Fort",
     "wof:parent_id":85632369,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.